### PR TITLE
WIP removed explicit tag tefinition from config

### DIFF
--- a/helmfile.d/config/postgresql-values.yaml.gotmpl
+++ b/helmfile.d/config/postgresql-values.yaml.gotmpl
@@ -1,7 +1,6 @@
 image:
   registry: docker.io
   repository: bitnami/postgresql
-  tag: 11.13.0-debian-10-r61
   pullPolicy: IfNotPresent
   debug: false
 volumePermissions:
@@ -9,7 +8,6 @@ volumePermissions:
   image:
     registry: docker.io
     repository: bitnami/bitnami-shell
-    tag: 10-debian-10-r220
     pullPolicy: Always
   securityContext:
     runAsUser: 0
@@ -123,7 +121,6 @@ metrics:
   image:
     registry: docker.io
     repository: bitnami/postgres-exporter
-    tag: 0.10.0-debian-10-r101
     pullPolicy: IfNotPresent
     ## Optionally specify an array of imagePullSecrets.
     ## Secrets must be manually created in the namespace.


### PR DESCRIPTION
this way is much safer and cleaner since we don't have a specific use case for an explicit tag definition